### PR TITLE
Make BuildFile work without a controller context

### DIFF
--- a/Rotativa.Demo/Models/AccountModels.cs
+++ b/Rotativa.Demo/Models/AccountModels.cs
@@ -23,7 +23,7 @@ namespace Rotativa.Demo.Models
 
         [DataType(DataType.Password)]
         [Display(Name = "Confirm new password")]
-        [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
+        [System.ComponentModel.DataAnnotations.Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; }
     }
 
@@ -61,7 +61,7 @@ namespace Rotativa.Demo.Models
 
         [DataType(DataType.Password)]
         [Display(Name = "Confirm password")]
-        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+		[System.ComponentModel.DataAnnotations.Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; }
     }
 }

--- a/Rotativa.Demo/Rotativa.Demo.csproj
+++ b/Rotativa.Demo/Rotativa.Demo.csproj
@@ -8,12 +8,12 @@
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{8EC08BFB-6ABA-4D71-8405-77AFF5859F3D}</ProjectGuid>
-    <ProjectTypeGuids>{E53F8FEA-EAE0-44A6-8774-FFD645390401};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rotativa.Demo</RootNamespace>
     <AssemblyName>Rotativa.Demo</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -27,6 +27,8 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <MvcProjectUpgradeChecked>true</MvcProjectUpgradeChecked>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,6 +38,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -44,23 +47,53 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="System.Web.Mvc, Version=3.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controllers\AccountController.cs" />

--- a/Rotativa.Demo/Views/Web.config
+++ b/Rotativa.Demo/Views/Web.config
@@ -2,14 +2,14 @@
 
 <configuration>
   <configSections>
-    <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
-      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
-      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
-    </sectionGroup>
+		<sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+			<section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+			<section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+		</sectionGroup>
   </configSections>
 
   <system.web.webPages.razor>
-    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+		<host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
     <pages pageBaseType="System.Web.Mvc.WebViewPage">
       <namespaces>
         <add namespace="System.Web.Mvc" />
@@ -36,13 +36,9 @@
         To change this behavior apply the ValidateInputAttribute to a
         controller or action.
     -->
-    <pages
-        validateRequest="false"
-        pageParserFilterType="System.Web.Mvc.ViewTypeParserFilter, System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
-        pageBaseType="System.Web.Mvc.ViewPage, System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35"
-        userControlBaseType="System.Web.Mvc.ViewUserControl, System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+		<pages validateRequest="false" pageParserFilterType="System.Web.Mvc.ViewTypeParserFilter, System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" pageBaseType="System.Web.Mvc.ViewPage, System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" userControlBaseType="System.Web.Mvc.ViewUserControl, System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
       <controls>
-        <add assembly="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" namespace="System.Web.Mvc" tagPrefix="mvc" />
+				<add assembly="System.Web.Mvc, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" namespace="System.Web.Mvc" tagPrefix="mvc" />
       </controls>
     </pages>
   </system.web>

--- a/Rotativa.Demo/Web.config
+++ b/Rotativa.Demo/Web.config
@@ -1,91 +1,90 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=152368
   -->
-
 <configuration>
   <connectionStrings>
     <add name="ApplicationServices"
-         connectionString="data source=.\SQLEXPRESS;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|aspnetdb.mdf;User Instance=true"
-         providerName="System.Data.SqlClient" />
+      connectionString="data source=.\SQLEXPRESS;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|aspnetdb.mdf;User Instance=true"
+      providerName="System.Data.SqlClient"/>
   </connectionStrings>
-
   <appSettings>
-    <add key="webpages:Version" value="1.0.0.0"/>
+    <add key="webpages:Version" value="3.0.0.0"/>
     <add key="ClientValidationEnabled" value="true"/>
     <add key="UnobtrusiveJavaScriptEnabled" value="true"/>
     <add key="WkhtmltopdfPath" value=""/>
   </appSettings>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.5" />
+      </system.Web>
+  -->
   <system.web>
-    <compilation debug="true" targetFramework="4.0">
-      <assemblies>
-        <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Routing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-        <add assembly="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
-      </assemblies>
+    <compilation debug="true" targetFramework="4.5">
+      <assemblies/>
     </compilation>
-
     <authentication mode="Forms">
-      <forms loginUrl="~/Account/LogOn" timeout="2880" />
+      <forms loginUrl="~/Account/LogOn" timeout="2880"/>
     </authentication>
-
     <membership>
       <providers>
         <clear/>
         <add name="AspNetSqlMembershipProvider" type="System.Web.Security.SqlMembershipProvider" connectionStringName="ApplicationServices"
-             enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" requiresUniqueEmail="false"
-             maxInvalidPasswordAttempts="5" minRequiredPasswordLength="6" minRequiredNonalphanumericCharacters="0" passwordAttemptWindow="10"
-             applicationName="/" />
+          enablePasswordRetrieval="false" enablePasswordReset="true" requiresQuestionAndAnswer="false" requiresUniqueEmail="false"
+          maxInvalidPasswordAttempts="5" minRequiredPasswordLength="6" minRequiredNonalphanumericCharacters="0" passwordAttemptWindow="10" applicationName="/"/>
       </providers>
     </membership>
-
     <profile>
       <providers>
         <clear/>
-        <add name="AspNetSqlProfileProvider" type="System.Web.Profile.SqlProfileProvider" connectionStringName="ApplicationServices" applicationName="/" />
+        <add name="AspNetSqlProfileProvider" type="System.Web.Profile.SqlProfileProvider" connectionStringName="ApplicationServices" applicationName="/"/>
       </providers>
     </profile>
-
     <roleManager enabled="false">
       <providers>
         <clear/>
-        <add name="AspNetSqlRoleProvider" type="System.Web.Security.SqlRoleProvider" connectionStringName="ApplicationServices" applicationName="/" />
-        <add name="AspNetWindowsTokenRoleProvider" type="System.Web.Security.WindowsTokenRoleProvider" applicationName="/" />
+        <add name="AspNetSqlRoleProvider" type="System.Web.Security.SqlRoleProvider" connectionStringName="ApplicationServices" applicationName="/"/>
+        <add name="AspNetWindowsTokenRoleProvider" type="System.Web.Security.WindowsTokenRoleProvider" applicationName="/"/>
       </providers>
     </roleManager>
-
-    <pages>
+    <pages controlRenderingCompatibilityVersion="4.0">
       <namespaces>
-        <add namespace="System.Web.Helpers" />
-        <add namespace="System.Web.Mvc" />
-        <add namespace="System.Web.Mvc.Ajax" />
-        <add namespace="System.Web.Mvc.Html" />
-        <add namespace="System.Web.Routing" />
+        <add namespace="System.Web.Helpers"/>
+        <add namespace="System.Web.Mvc"/>
+        <add namespace="System.Web.Mvc.Ajax"/>
+        <add namespace="System.Web.Mvc.Html"/>
+        <add namespace="System.Web.Routing"/>
         <add namespace="System.Web.WebPages"/>
       </namespaces>
     </pages>
   </system.web>
-
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false"/>
     <modules runAllManagedModulesForAllRequests="true"/>
     <httpProtocol>
       <customHeaders>
-        <clear />
-        <add name="Access-Control-Allow-Origin" value="*" />
+        <clear/>
+        <add name="Access-Control-Allow-Origin" value="*"/>
       </customHeaders>
     </httpProtocol>
   </system.webServer>
-
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-2.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Rotativa.Demo/packages.config
+++ b/Rotativa.Demo/packages.config
@@ -4,5 +4,9 @@
   <package id="jQuery.UI.Combined" version="1.8.11" />
   <package id="jQuery.Validation" version="1.8.0" />
   <package id="jQuery.vsdoc" version="1.5.1" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="1.7" />
 </packages>

--- a/Rotativa.Tests/App.config
+++ b/Rotativa.Tests/App.config
@@ -1,6 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="RotativaDemoUrl" value="http://localhost:12237/"/>
+    <add key="RotativaDemoUrl" value="http://localhost:12237/" />
   </appSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Rotativa.Tests/Rotativa.Tests.csproj
+++ b/Rotativa.Tests/Rotativa.Tests.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rotativa.Tests</RootNamespace>
     <AssemblyName>Rotativa.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="itextsharp">
@@ -79,6 +82,23 @@
       <Link>chromedriver.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Rotativa.Demo\Rotativa.Demo.csproj">
+      <Project>{8ec08bfb-6aba-4d71-8405-77aff5859f3d}</Project>
+      <Name>Rotativa.Demo</Name>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </ProjectReference>
+    <ProjectReference Include="..\Rotativa\Rotativa.csproj">
+      <Project>{d93faa11-31f0-4629-b53c-aa8680283529}</Project>
+      <Name>Rotativa</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/Rotativa.UnitTests/BinaryTests.cs
+++ b/Rotativa.UnitTests/BinaryTests.cs
@@ -27,7 +27,7 @@ namespace Rotativa.UnitTests
         public void Can_build_the_pdf_binary()
         {
             var localPath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
-            var solutionDir = localPath.Parent.Parent.FullName;
+            var solutionDir = localPath.Parent.Parent.Parent.FullName;
             var wkhtmltopdfPath = Path.Combine(solutionDir, "Rotativa", "Rotativa");
             var actionResult = new UrlAsPdf("https://github.com/webgio/Rotativa")
                 {
@@ -36,7 +36,7 @@ namespace Rotativa.UnitTests
             var builder = new TestControllerBuilder();
             var controller = new HomeController();
             builder.InitializeController(controller);
-            var pdfBinary = actionResult.BuildPdf(controller.ControllerContext);
+            var pdfBinary = actionResult.BuildPdf();
             var pdfTester = new PdfTester();
             pdfTester.LoadPdf(pdfBinary);
             pdfTester.PdfIsValid.Should().Be.True();
@@ -47,7 +47,7 @@ namespace Rotativa.UnitTests
         public void Can_build_the_image_binary()
         {
             var localPath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
-            var solutionDir = localPath.Parent.Parent.FullName;
+			var solutionDir = localPath.Parent.Parent.Parent.FullName;
             var wkhtmltoimagePath = Path.Combine(solutionDir, "Rotativa", "Rotativa");
             var actionResult = new UrlAsImage("https://github.com/webgio/Rotativa")
             {

--- a/Rotativa.UnitTests/Rotativa.UnitTests.csproj
+++ b/Rotativa.UnitTests/Rotativa.UnitTests.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Rotativa.UnitTests</RootNamespace>
     <AssemblyName>Rotativa.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -23,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,8 +33,13 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="MvcContrib.TestHelper">
       <HintPath>..\packages\MvcContrib.Mvc3.TestHelper-ci.3.0.100.0\lib\MvcContrib.TestHelper.dll</HintPath>
     </Reference>
@@ -56,7 +63,30 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Mvc, Version=3.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -72,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rotativa.Demo\Rotativa.Demo.csproj">
-      <Project>{8EC08BFB-6ABA-4D71-8405-77AFF5859F3D}</Project>
+      <Project>{8ec08bfb-6aba-4d71-8405-77aff5859f3d}</Project>
       <Name>Rotativa.Demo</Name>
     </ProjectReference>
     <ProjectReference Include="..\Rotativa.Tests\Rotativa.Tests.csproj">
@@ -85,10 +115,14 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="MvcIntegrationTestFramework\MvcIntegrationTestFramework.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/Rotativa.UnitTests/WkhtmltoimageCommandLineStringTests.cs
+++ b/Rotativa.UnitTests/WkhtmltoimageCommandLineStringTests.cs
@@ -16,7 +16,7 @@ namespace Rotativa.UnitTests
             {
                 return base.GetConvertOptions();
             }
-            protected override string GetUrl(System.Web.Mvc.ControllerContext context)
+            protected override string GetUrl(System.Web.HttpContext context)
             {
                 return string.Empty;
             }

--- a/Rotativa.UnitTests/WkhtmltopdfCommandLineStringTests.cs
+++ b/Rotativa.UnitTests/WkhtmltopdfCommandLineStringTests.cs
@@ -14,7 +14,7 @@ namespace Rotativa.UnitTests
         {
             return base.GetConvertOptions();
         }
-        protected override string GetUrl(System.Web.Mvc.ControllerContext context)
+        protected override string GetUrl(System.Web.HttpContext context)
         {
             return string.Empty;
         }

--- a/Rotativa.UnitTests/app.config
+++ b/Rotativa.UnitTests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.5" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/Rotativa.UnitTests/packages.config
+++ b/Rotativa.UnitTests/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MvcContrib.Mvc3.TestHelper-ci" version="3.0.100.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="MvcContrib.Mvc3.TestHelper-ci" version="3.0.100.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.0.12054" targetFramework="net40" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
   <package id="SharpTestsEx" version="1.1.1" targetFramework="net40" />

--- a/Rotativa.sln
+++ b/Rotativa.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C58DBD7F-8582-4005-AD32-E94AB45A338F}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config

--- a/Rotativa/ActionAsImage.cs
+++ b/Rotativa/ActionAsImage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -27,9 +28,9 @@ namespace Rotativa
             this.routeValues = routeValues;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
-            var urlHelper = new UrlHelper(context.RequestContext);
+            var urlHelper = new UrlHelper(context.Request.RequestContext);
 
             string actionUrl = string.Empty;
             if (this.routeValues == null)
@@ -39,7 +40,7 @@ namespace Rotativa
             else
                 actionUrl = urlHelper.Action(this.action);
 
-            string url = String.Format("{0}://{1}{2}", context.HttpContext.Request.Url.Scheme, context.HttpContext.Request.Url.Authority, actionUrl);
+            string url = String.Format("{0}://{1}{2}", context.Request.Url.Scheme, context.Request.Url.Authority, actionUrl);
             return url;
         }
     }

--- a/Rotativa/ActionAsPdf.cs
+++ b/Rotativa/ActionAsPdf.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -28,9 +29,9 @@ namespace Rotativa
             this.routeValues = routeValues;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
-            var urlHelper = new UrlHelper(context.RequestContext);
+            var urlHelper = new UrlHelper(context.Request.RequestContext);
 
             string actionUrl = string.Empty;
             if (this.routeValues == null)
@@ -40,7 +41,7 @@ namespace Rotativa
             else
                 actionUrl = urlHelper.Action(this.action);
 
-            string url = String.Format("{0}://{1}{2}", context.HttpContext.Request.Url.Scheme, context.HttpContext.Request.Url.Authority, actionUrl);
+            string url = String.Format("{0}://{1}{2}", context.Request.Url.Scheme, context.Request.Url.Authority, actionUrl);
             return url;
         }
     }

--- a/Rotativa/AsPdfResultBase.cs
+++ b/Rotativa/AsPdfResultBase.cs
@@ -103,7 +103,7 @@ namespace Rotativa
         }
 
         [Obsolete(@"Use BuildFile(this.ControllerContext) method instead.")]
-        public byte[] BuildPdf(ControllerContext context)
+        public byte[] BuildPdf(ControllerContext context = null)
         {
             return BuildFile(context);
         }

--- a/Rotativa/AsResultBase.cs
+++ b/Rotativa/AsResultBase.cs
@@ -102,7 +102,7 @@ namespace Rotativa
         [Obsolete(@"Use BuildFile(this.ControllerContext) method instead and use the resulting binary data to do what needed.")]
         public string SaveOnServerPath { get; set; }
 
-        protected abstract string GetUrl(ControllerContext context);
+		protected abstract string GetUrl(HttpContext context);
 
         /// <summary>
         /// Returns properties with OptionFlag attribute as one line that can be passed to wkhtmltopdf binary.
@@ -145,14 +145,15 @@ namespace Rotativa
             return result.ToString().Trim();
         }
 
-        private string GetWkParams(ControllerContext context)
+        private string GetWkParams(ControllerContext context = null)
         {
+			var httpContext = HttpContext.Current;
             var switches = string.Empty;
 
             HttpCookie authenticationCookie = null;
-            if (context.HttpContext.Request.Cookies != null && context.HttpContext.Request.Cookies.AllKeys.Contains(FormsAuthentication.FormsCookieName))
+			if (httpContext != null && httpContext.Request.Cookies != null && httpContext.Request.Cookies.AllKeys.Contains(FormsAuthentication.FormsCookieName))
             {
-                authenticationCookie = context.HttpContext.Request.Cookies[FormsAuthentication.FormsCookieName];
+				authenticationCookie = httpContext.Request.Cookies[FormsAuthentication.FormsCookieName];
             }
             if (authenticationCookie != null)
             {
@@ -162,13 +163,13 @@ namespace Rotativa
 
             switches += " " + this.GetConvertOptions();
 
-            var url = this.GetUrl(context);
+            var url = this.GetUrl(httpContext);
             switches += " " + url;
 
             return switches;
         }
 
-        protected virtual byte[] CallTheDriver(ControllerContext context)
+        protected virtual byte[] CallTheDriver(ControllerContext context = null)
         {
             var switches = this.GetWkParams(context);
             var fileContent = this.WkhtmlConvert(switches);
@@ -177,10 +178,8 @@ namespace Rotativa
 
         protected abstract byte[] WkhtmlConvert(string switches);
 
-        public byte[] BuildFile(ControllerContext context)
+        public byte[] BuildFile(ControllerContext context = null)
         {
-            if (context == null)
-                throw new ArgumentNullException("context");
 
             if (this.WkhtmlPath == string.Empty)
                 this.WkhtmlPath = HttpContext.Current.Server.MapPath("~/Rotativa");

--- a/Rotativa/AsResultBase.cs
+++ b/Rotativa/AsResultBase.cs
@@ -180,9 +180,8 @@ namespace Rotativa
 
         public byte[] BuildFile(ControllerContext context = null)
         {
-
             if (this.WkhtmlPath == string.Empty)
-                this.WkhtmlPath = HttpContext.Current.Server.MapPath("~/Rotativa");
+                this.WkhtmlPath = context == null ? HttpContext.Current.Server.MapPath("~/Rotativa") : context.HttpContext.Server.MapPath("~/Rotativa");
 
             var fileContent = this.CallTheDriver(context);
 

--- a/Rotativa/RouteAsImage.cs
+++ b/Rotativa/RouteAsImage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -28,9 +29,9 @@ namespace Rotativa
             this.routeValues = routeValues;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
-            var urlHelper = new UrlHelper(context.RequestContext);
+            var urlHelper = new UrlHelper(context.Request.RequestContext);
 
             string actionUrl = string.Empty;
             if (this.routeValues == null)
@@ -40,7 +41,7 @@ namespace Rotativa
             else
                 actionUrl = urlHelper.RouteUrl(this.routeName);
 
-            string url = String.Format("{0}://{1}{2}", context.HttpContext.Request.Url.Scheme, context.HttpContext.Request.Url.Authority, actionUrl);
+            string url = String.Format("{0}://{1}{2}", context.Request.Url.Scheme, context.Request.Url.Authority, actionUrl);
             return url;
         }
     }

--- a/Rotativa/RouteAsPdf.cs
+++ b/Rotativa/RouteAsPdf.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
 
@@ -28,9 +29,9 @@ namespace Rotativa
             this.routeValues = routeValues;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
-            var urlHelper = new UrlHelper(context.RequestContext);
+            var urlHelper = new UrlHelper(context.Request.RequestContext);
 
             string actionUrl = string.Empty;
             if (this.routeValues == null)
@@ -40,7 +41,7 @@ namespace Rotativa
             else
                 actionUrl = urlHelper.RouteUrl(this.routeName);
 
-            string url = String.Format("{0}://{1}{2}", context.HttpContext.Request.Url.Scheme, context.HttpContext.Request.Url.Authority, actionUrl);
+            string url = String.Format("{0}://{1}{2}", context.Request.Url.Scheme, context.Request.Url.Authority, actionUrl);
             return url;
         }
     }

--- a/Rotativa/UrlAsImage.cs
+++ b/Rotativa/UrlAsImage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 
 namespace Rotativa
@@ -12,13 +13,13 @@ namespace Rotativa
             _url = url ?? string.Empty;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
             string urlLower = _url.ToLower();
             if (urlLower.StartsWith("http://") || urlLower.StartsWith("https://"))
                 return _url;
 
-            string url = String.Format("{0}://{1}{2}", context.HttpContext.Request.Url.Scheme, context.HttpContext.Request.Url.Authority, _url);
+            string url = String.Format("{0}://{1}{2}", context.Request.Url.Scheme, context.Request.Url.Authority, _url);
             return url;
         }
     }

--- a/Rotativa/UrlAsPdf.cs
+++ b/Rotativa/UrlAsPdf.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Web;
 using System.Web.Mvc;
 
 namespace Rotativa
@@ -12,13 +13,13 @@ namespace Rotativa
             _url = url ?? string.Empty;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
             string urlLower = _url.ToLower();
             if (urlLower.StartsWith("http://") || urlLower.StartsWith("https://"))
                 return _url;
 
-            string url = String.Format("{0}://{1}{2}", context.HttpContext.Request.Url.Scheme, context.HttpContext.Request.Url.Authority, _url);
+            string url = String.Format("{0}://{1}{2}", context.Request.Url.Scheme, context.Request.Url.Authority, _url);
             return url;
         }
     }

--- a/Rotativa/ViewAsImage.cs
+++ b/Rotativa/ViewAsImage.cs
@@ -1,5 +1,6 @@
 using System.Web.Mvc;
 using Rotativa.Extensions;
+using System.Web;
 
 namespace Rotativa
 {
@@ -56,7 +57,7 @@ namespace Rotativa
             MasterName = masterName;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
             return string.Empty;
         }

--- a/Rotativa/ViewAsPdf.cs
+++ b/Rotativa/ViewAsPdf.cs
@@ -1,5 +1,6 @@
 ﻿using System.Web.Mvc;
 using Rotativa.Extensions;
+using System.Web;
 
 namespace Rotativa
 {
@@ -56,7 +57,7 @@ namespace Rotativa
             MasterName = masterName;
         }
 
-        protected override string GetUrl(ControllerContext context)
+        protected override string GetUrl(HttpContext context)
         {
             return string.Empty;
         }


### PR DESCRIPTION
I've been using this project for a few years now and more than once I've had to modify it to remove the dependency on `ControllerContext` so that I could create PDFs in WebAPI and outside of a normal MVC Controller. `ControllerContext` in most cases was replaceable by `HttpContext.Current`.

To perform the tests I had to update the demo and the unit tests to MVC 5. After the update all of the tests passed successfully.
