### PR TITLE
Added content disposition parameter

### DIFF
--- a/Rotativa/AsResultBase.cs
+++ b/Rotativa/AsResultBase.cs
@@ -102,6 +102,8 @@ namespace Rotativa
         [Obsolete(@"Use BuildFile(this.ControllerContext) method instead and use the resulting binary data to do what needed.")]
         public string SaveOnServerPath { get; set; }
 
+        public ContentDisposition ContentDisposition { get; set; }
+
         protected abstract string GetUrl(ControllerContext context);
 
         /// <summary>
@@ -218,8 +220,13 @@ namespace Rotativa
             response.ContentType = this.GetContentType();
 
             if (!String.IsNullOrEmpty(this.FileName))
-                response.AddHeader("Content-Disposition", string.Format("attachment; filename=\"{0}\"", SanitizeFileName(this.FileName)));
+            {
+                var contentDisposition = this.ContentDisposition == ContentDisposition.Attachment
+                    ? "attachment"
+                    : "inline";
 
+                response.AddHeader("Content-Disposition", string.Format("{0}; filename=\"{1}\"", contentDisposition, SanitizeFileName(this.FileName)));
+            }
             response.AddHeader("Content-Type", this.GetContentType());
 
             return response;

--- a/Rotativa/Options/Enums.cs
+++ b/Rotativa/Options/Enums.cs
@@ -174,4 +174,10 @@ namespace Rotativa.Options
         jpeg,
         png
     }
+
+    public enum ContentDisposition
+    {
+        Attachment = 0, // this is the default
+        Inline
+    }
 }


### PR DESCRIPTION
I've added a parameter to set the value of Content-Disposition on the HTTP response.

This option is useful because the user can either right-click on the link, select "Save Link As" and get a sensible filename or simply left-click on the link and have the document open in the browser.