### PR TITLE
Replace references to HttpContext.Current with ControllerContext Http…

### DIFF
--- a/Rotativa/AsResultBase.cs
+++ b/Rotativa/AsResultBase.cs
@@ -185,7 +185,7 @@ namespace Rotativa
                 throw new ArgumentNullException("context");
 
             if (this.WkhtmlPath == string.Empty)
-                this.WkhtmlPath = HttpContext.Current.Server.MapPath("~/Rotativa");
+                this.WkhtmlPath = context.HttpContext.Server.MapPath("~/Rotativa");
 
             var fileContent = this.CallTheDriver(context);
 

--- a/Rotativa/Extensions/ControllerContextExtensions.cs
+++ b/Rotativa/Extensions/ControllerContextExtensions.cs
@@ -35,7 +35,7 @@
                 viewResult.View.Render(viewContext, sw);
 
                 string html = sw.GetStringBuilder().ToString();
-                string baseUrl = string.Format("{0}://{1}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Authority);
+                string baseUrl = string.Format("{0}://{1}", context.HttpContext.Request.Url.Scheme, HttpContext.Current.Request.Url.Authority);
                 html = Regex.Replace(html, "<head>", string.Format("<head><base href=\"{0}\" />", baseUrl), RegexOptions.IgnoreCase);
                 return html;
             }


### PR DESCRIPTION
Replace references to HttpContext.Current with ControllerContext HttpContext references to ensure AsResultBase.BuildFile doesn't break when being called from async/await code.

Tests all pass (and my invoking code now works 👍).